### PR TITLE
Add limits configuration for commits and branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ It uses JGit under the hood to read repository data and renders a scrollable hor
 - Beautiful horizontal DAG graph of commits (nodes with smooth curved edges)
 - Shows branches, tags, and remotes as badges near nodes
 - Displays author and short message as labels
+- Limits button to choose how many latest commits and latest branches to show (defaults: 500 commits, 20 branches)
 - Scales to the full history of your repo (no artificial 200-commit limit)
 
 ## Requirements


### PR DESCRIPTION
- Introduced a "Limits" button to configure the maximum number of commits (default: 500) and branches (default: 20) displayed in the graph.
- Enabled sorting and limiting of branches by most recent commit time.
- Updated commit collection logic to respect configured limits.
- Improved UI with configurable popups for limit settings.